### PR TITLE
Add Verbose Logging Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ jobs:
    - `notification-summary` (required), Your custom notification message (ex. Deployment Started or Build Successful)
    - `notification-color` (optional), Custom color to help distinguish type of notification. Can be any [HEX color](https://html-color.codes/). (ex. **007bff** or **17a2b8** for info, **28a745** success, **ffc107** warning, **dc3545** error, etc.) 
    - `timezone` - (optional, defaults to `UTC`), a [valid database timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), (ex. Australia/Sydney or America/Denver, etc.)
-   - `vebose-logging` - (optional, defaults to `false`), Emits additional logging showing the sent message card and response from the webhook.
+   - `verbose-logging` - (optional, defaults to `false`), Emits additional logging showing the sent message card and response from the webhook.
 
 ## Examples
 As you can see below, the `notification-summary` and `notification-color` are being used to customize the appearance of the message. Use bright vibrant colors to notify your Microsoft Teams channel of warnings or errors in your GitHub Actions workflow.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jobs:
           notification-summary: Your custom notification message 
           notification-color: 17a2b8
           timezone: America/Denver
+          verbose-logging: true
 ```
 
 3. Make it your own with the following configurations.
@@ -39,6 +40,7 @@ jobs:
    - `notification-summary` (required), Your custom notification message (ex. Deployment Started or Build Successful)
    - `notification-color` (optional), Custom color to help distinguish type of notification. Can be any [HEX color](https://html-color.codes/). (ex. **007bff** or **17a2b8** for info, **28a745** success, **ffc107** warning, **dc3545** error, etc.) 
    - `timezone` - (optional, defaults to `UTC`), a [valid database timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), (ex. Australia/Sydney or America/Denver, etc.)
+   - `vebose-logging` - (optional, defaults to `false`), Emits additional logging showing the sent message card and response from the webhook.
 
 ## Examples
 As you can see below, the `notification-summary` and `notification-color` are being used to customize the appearance of the message. Use bright vibrant colors to notify your Microsoft Teams channel of warnings or errors in your GitHub Actions workflow.

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   timezone:
     description: 'Timezone (ex. America/Denver)'
     required: false
+  verbose-logging:
+    description: 'Enable verbose logging'
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,7 @@ inputs:
     required: false
   verbose-logging:
     description: 'Enable verbose logging'
+    default: 'false'
     required: false
 runs:
   using: 'node12'

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ async function run(): Promise<void> {
       core.getInput('notification-summary') || 'GitHub Action Notification'
     const notificationColor = core.getInput('notification-color') || '0b93ff'
     const timezone = core.getInput('timezone') || 'UTC'
-    const verboseLogging: boolean = core.getInput('verbose-logging')
+    const verboseLogging = core.getInput('verbose-logging')
     const timestamp = moment()
       .tz(timezone)
       .format('dddd, MMMM Do YYYY, h:mm:ss a z')

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,12 +20,11 @@ async function run(): Promise<void> {
     const msTeamsWebhookUri: string = core.getInput('ms-teams-webhook-uri', {
       required: true
     })
-
     const notificationSummary =
       core.getInput('notification-summary') || 'GitHub Action Notification'
     const notificationColor = core.getInput('notification-color') || '0b93ff'
     const timezone = core.getInput('timezone') || 'UTC'
-
+    const verboseLogging: boolean = core.getInput('verbose-logging')
     const timestamp = moment()
       .tz(timezone)
       .format('dddd, MMMM Do YYYY, h:mm:ss a z')
@@ -55,12 +54,16 @@ async function run(): Promise<void> {
       timestamp
     )
 
-    console.log(messageCard)
+    if(verboseLogging){
+      console.log(messageCard)
+    }
 
     axios
       .post(msTeamsWebhookUri, messageCard)
       .then(function(response) {
-        console.log(response)
+        if(verboseLogging){
+          console.log(response)
+        }
         core.debug(response.data)
       })
       .catch(function(error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ async function run(): Promise<void> {
     const msTeamsWebhookUri: string = core.getInput('ms-teams-webhook-uri', {
       required: true
     })
+
     const notificationSummary =
       core.getInput('notification-summary') || 'GitHub Action Notification'
     const notificationColor = core.getInput('notification-color') || '0b93ff'


### PR DESCRIPTION
Problem: This action emits a large amount of logging by default. When used in a composite action with other steps, this action will eclipse the logs of other steps.

Example:
<img width="1064" alt="image" src="https://user-images.githubusercontent.com/619450/166300039-f0b34155-ace9-4cb4-8963-e6bc5b042936.png">

Solution: Add Verbose Logging Control via an optional "verbose-logging" input.

I have not tested these changes.
